### PR TITLE
添加自定义查询时间功能

### DIFF
--- a/Toefl.js
+++ b/Toefl.js
@@ -1,7 +1,11 @@
 //在这里加入你需要选择的城市。
-var city_choose = ["武汉","郑州","长沙"]
+var city_choose = ["武汉","长沙","南昌"]
+
 //在这里加入你需要选择的时间[start_time,end_time]。
 var time_start_end = ["2021-4-10","2021-10-30"]
+
+//搜索全部时间
+//var time_start_end = ["2000-4-10","2099-10-30"]
 
 function sleep(ms) {
   return new Promise(resolve => setTimeout(resolve, ms))

--- a/Toefl.js
+++ b/Toefl.js
@@ -1,5 +1,7 @@
 //在这里加入你需要选择的城市。
 var city_choose = ["武汉","郑州","长沙"]
+//在这里加入你需要选择的时间[start_time,end_time]。
+var time_start_end = ["2021-4-10","2021-10-30"]
 
 function sleep(ms) {
   return new Promise(resolve => setTimeout(resolve, ms))
@@ -17,20 +19,31 @@ async function Scanner(city_choose, all) {
         for(n = 0; n < city_choose.length; n++){
             if(city_choose[n]==city.options[i].text||all==true){ //如果找到了指定的城市
                 city.options[i].selected = true
-                for (j = 1; j < 18; ++j) {
-                    day.options[j].selected = true
-                    btn_query.click()
-                    await sleep(1000)
-                    tables = document.getElementsByClassName("table table-bordered table-striped")
-                    if (tables.length == 1) {
-                        tb = tables[0]
-                        for (row = 2; row < tb.rows.length; ++row) {
-                            if (tb.rows[row].cells[3].innerText == "有名额") {
-                                console.log(
-                                    city.options[i].innerText,
-                                    day.options[j].innerText,
-                                    tb.rows[row].cells[1].innerText)
-}}}}}}}}
+                for (j = 1; j < day.options.length; ++j) {
+                    if(compare(day.options[j].text)){ //如果找到了指定范围内的时间
+                        day.options[j].selected = true
+                        btn_query.click()
+                        await sleep(1000)
+                        tables = document.getElementsByClassName("table table-bordered table-striped")
+                        if (tables.length == 1) {
+                            tb = tables[0]
+                            for (row = 2; row < tb.rows.length; ++row) {
+                                if (tb.rows[row].cells[3].innerText == "有名额") {
+                                    console.log(
+                                        city.options[i].innerText,
+                                        day.options[j].innerText,
+                                        tb.rows[row].cells[1].innerText)
+}}}}}}}}}
+
+
+function compare(date){
+    
+    var cur = new Date(date.slice(0,date.indexOf("日")).replace("年","-").replace("月","-"));
+    var start = new Date(time_start_end[0]);
+    var end = new Date(time_start_end[1])
+
+    return cur.getTime() >= start.getTime() && cur.getTime() <= end.getTime()
+}
 
 //搜索指定城市
 //Scanner(city_choose, false)


### PR DESCRIPTION
自定义查询的时间范围 2021年4月10日至2021年10月30日（包含开始结束日）
例如：
`var time_start_end = ["2021-4-10","2021-10-30"]` 

若想查询所有考试时间，则将开始时间、结束时间设置为date.options范围以外即可，
例如：
`var time_start_end = ["2000-4-10","2099-10-30"]`